### PR TITLE
Chart improvements from the Camel F2F workshop

### DIFF
--- a/api-specification-pipeline/templates/maven-pipeline.yaml
+++ b/api-specification-pipeline/templates/maven-pipeline.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.component }}-api
 spec:
   description: | 
-    This pipeline runs a Spectral linter against an API specification and publishes to Microcks
+    This pipeline runs a Spectral linter against an API specification and publishes to Microcks and Apicurio Registry
   params:
   - default: https://github.com/{{ .Values.domain }}/{{ .Values.system }}-{{ .Values.component }}-api
     name: repo-url
@@ -37,7 +37,6 @@ spec:
     workspaces:
     - name: output
       workspace: shared-data
-  {{- if .Values.mock_provider_url }}
   - name: run-spectral
     runAfter: ["fetch-source"]
     taskRef:
@@ -61,42 +60,11 @@ spec:
     workspaces:
     - name: data
       workspace: shared-data
-  {{- end }}
-  {{- if .Values.apicurioRegistry }}
-  - name: clean-artifacts
-    taskRef:
-      name: maven
-      kind: ClusterTask
-    runAfter: 
-      - fetch-source
-    params:
-    - name: GOALS
-      value: 
-        - build-helper:remove-project-artifact
-    workspaces:
-      - name: source
-        workspace: shared-data
-      - name: maven-settings
-        workspace: maven-settings
-  - name: clean-registered-artifact
-    taskRef:
-      name: curl
-      kind: Task
-    runAfter:
-      - clean-artifacts
-    params:
-      - name: url
-        value: "{{ .Values.apicurioRegistry }}/apis/registry/v2/groups/{{ .Values.groupid }}/artifacts/{{ .Values.component }}"
-      - name: options
-        value:
-          - "-X"
-          - "DELETE"
   - name: register-apicurio
     taskRef:
       name: maven
       kind: ClusterTask
-    runAfter: 
-      - clean-registered-artifact
+    runAfter: ["run-spectral"]
     params:
     - name: GOALS
       value: 
@@ -106,4 +74,3 @@ spec:
         workspace: shared-data
       - name: maven-settings
         workspace: maven-settings
-  {{- end }}

--- a/api-specification-pipeline/templates/pipeline-pvc.yaml
+++ b/api-specification-pipeline/templates/pipeline-pvc.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.component }}-shared-data
+  name: {{ .Values.component }}-api-shared-data
 spec:
   resources:
     requests:
@@ -14,7 +14,7 @@ spec:
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.component }}-maven-settings
+  name: {{ .Values.component }}-api-maven-settings
 spec:
   resources:
     requests:

--- a/api-specification-pipeline/templates/pipeline-run-job.yaml
+++ b/api-specification-pipeline/templates/pipeline-run-job.yaml
@@ -18,7 +18,7 @@ spec:
               - /bin/sh
               - -c
               - |
-                (tkn task delete -f curl || true) && tkn hub install task curl && tkn pipeline start {{ .Values.component }}-api -w name=shared-data,claimName={{ .Values.component }}-api-shared-data -w name=maven-settings,claimName={{ .Values.component }}-maven-settings --use-param-defaults
+                (tkn task delete -f curl || true) && tkn hub install task curl && tkn pipeline start {{ .Values.component }}-api -w name=shared-data,claimName={{ .Values.component }}-api-shared-data -w name=maven-settings,claimName={{ .Values.component }}-api-maven-settings --use-param-defaults
             env:
               - name: HOME
                 value: /tekton/home

--- a/api-specification-pipeline/templates/pipeline-run-job.yaml
+++ b/api-specification-pipeline/templates/pipeline-run-job.yaml
@@ -18,7 +18,7 @@ spec:
               - /bin/sh
               - -c
               - |
-                (tkn task delete -f curl || true) && tkn hub install task curl && tkn pipeline start {{ .Values.component }}-api -w name=shared-data,claimName={{ .Values.component }}-shared-data -w name=maven-settings,claimName={{ .Values.component }}-maven-settings --use-param-defaults
+                (tkn task delete -f curl || true) && tkn hub install task curl && tkn pipeline start {{ .Values.component }}-api -w name=shared-data,claimName={{ .Values.component }}-api-shared-data -w name=maven-settings,claimName={{ .Values.component }}-maven-settings --use-param-defaults
             env:
               - name: HOME
                 value: /tekton/home

--- a/api-specification-pipeline/templates/webhook-secret.yaml
+++ b/api-specification-pipeline/templates/webhook-secret.yaml
@@ -1,7 +1,7 @@
 kind: Secret
 apiVersion: v1
 metadata:
-  name: {{ .Values.component }}-webhook-secret
+  name: {{ .Values.component }}-api-webhook-secret
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 data:

--- a/quarkus-pipeline/templates/maven-pipeline.yaml
+++ b/quarkus-pipeline/templates/maven-pipeline.yaml
@@ -159,3 +159,12 @@ spec:
     - name: DOCKERFILE
       value: $(params.dockerfilePath)
   {{ end }}
+  - name: deploy-to-dev
+    runAfter: 
+      - build-container-image
+    taskRef:
+      name: openshift-client
+      kind: ClusterTask
+    params:
+    - name: SCRIPT
+      value: oc rollout restart deployment/{{ .Values.component }} -n {{ .Values.system }}-dev


### PR DESCRIPTION
- do not delete Apicurio Registry artifacts with pipeline, but rather assume existing artifact version will be overwritten using `<ifExists>RETURN_OR_UPDATE</ifExists>` in the apicurio-registry-maven plugin configuration if that is the desired behavior
- avoid naming collisions for pvc's and secrets when api and component share the same name (which is common)
- trigger a rollout in a system's dev environment when a new `latest` image version is published for a component (needs to be implemented for Spring Boot component pipeline as well)