### PR TITLE
consolidate pvc use in pipelines

### DIFF
--- a/api-specification-pipeline/templates/maven-settings.yaml
+++ b/api-specification-pipeline/templates/maven-settings.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.component }}-api-maven-settings
+data:
+  settings.xml: |
+    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+      <localRepository>/workspace/source/.m2</localRepository>
+    </settings>

--- a/api-specification-pipeline/templates/pipeline-pvc.yaml
+++ b/api-specification-pipeline/templates/pipeline-pvc.yaml
@@ -2,19 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.component }}-api-shared-data
-spec:
-  resources:
-    requests:
-      storage: 1Gi
-  volumeMode: Filesystem
-  accessModes:
-    - ReadWriteOnce
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ .Values.component }}-api-maven-settings
+  name: {{ .Values.component }}-api-workspace
 spec:
   resources:
     requests:

--- a/api-specification-pipeline/templates/pipeline-run-job.yaml
+++ b/api-specification-pipeline/templates/pipeline-run-job.yaml
@@ -18,7 +18,7 @@ spec:
               - /bin/sh
               - -c
               - |
-                (tkn task delete -f curl || true) && tkn hub install task curl && tkn pipeline start {{ .Values.component }}-api -w name=shared-data,claimName={{ .Values.component }}-api-shared-data -w name=maven-settings,claimName={{ .Values.component }}-api-maven-settings --use-param-defaults
+                (tkn task delete -f curl || true) && tkn hub install task curl && tkn pipeline start {{ .Values.component }}-api -w name=shared-data,claimName={{ .Values.component }}-api-workspace -w name=maven-settings,config={{ .Values.component }}-api-maven-settings --use-param-defaults
             env:
               - name: HOME
                 value: /tekton/home

--- a/api-specification-pipeline/templates/trigger-template.yaml
+++ b/api-specification-pipeline/templates/trigger-template.yaml
@@ -44,19 +44,9 @@ spec:
         serviceAccountName: pipeline
         workspaces:
           - name: shared-data
-            volumeClaimTemplate:
-              spec:
-                accessModes:
-                  - ReadWriteOnce
-                resources:
-                  requests:
-                    storage: 1Gi
+            persistentVolumeClaim:
+              claimName: {{ .Values.component }}-api-workspace
           - name: maven-settings
-            volumeClaimTemplate:
-              spec:
-                accessModes:
-                  - ReadWriteOnce
-                resources:
-                  requests:
-                    storage: 1Gi
+            configMap:
+              name: {{ .Values.component }}-api-maven-settings
 

--- a/quarkus-pipeline/templates/maven-pipeline.yaml
+++ b/quarkus-pipeline/templates/maven-pipeline.yaml
@@ -120,7 +120,7 @@ spec:
     - name: GOALS
       value: 
         - compile
-        - '-B'
+        - -B
     workspaces:
     - name: source
       workspace: maven-repo
@@ -138,7 +138,7 @@ spec:
       value: 
         - package
         - -DskipTests
-        - '-B'
+        - -B
         {{- if eq .Values.deployment "legacy-jar" }}
         - -Dquarkus.package.jar.type=legacy-jar
         {{ end }}

--- a/quarkus-pipeline/templates/maven-settings.yaml
+++ b/quarkus-pipeline/templates/maven-settings.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.component }}-maven-settings
+data:
+  settings.xml: |
+    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+      <localRepository>/workspace/source/.m2</localRepository>
+    </settings>

--- a/quarkus-pipeline/templates/pipeline-pvc.yaml
+++ b/quarkus-pipeline/templates/pipeline-pvc.yaml
@@ -2,19 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.component }}-maven-repo
-spec:
-  resources:
-    requests:
-      storage: 1Gi
-  volumeMode: Filesystem
-  accessModes:
-    - ReadWriteOnce
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ .Values.component }}-maven-settings
+  name: {{ .Values.component }}-workspace
 spec:
   resources:
     requests:

--- a/quarkus-pipeline/templates/pipeline-run-job.yaml
+++ b/quarkus-pipeline/templates/pipeline-run-job.yaml
@@ -18,7 +18,7 @@ spec:
               - /bin/sh
               - -c
               - |
-                tkn pipeline start {{ .Values.component }}-service -w name=maven-repo,claimName={{ .Values.component }}-maven-repo -w name=maven-settings,claimName={{ .Values.component }}-maven-settings --use-param-defaults
+                tkn pipeline start {{ .Values.component }}-service -w name=maven-repo,claimName={{ .Values.component }}-workspace -w name=maven-settings,config={{ .Values.component }}-maven-settings --use-param-defaults
             env:
               - name: HOME
                 value: /tekton/home

--- a/quarkus-pipeline/templates/trigger-template.yaml
+++ b/quarkus-pipeline/templates/trigger-template.yaml
@@ -38,19 +38,9 @@ spec:
           name: {{ .Values.component }}-service
         workspaces:
           - name: maven-repo
-            volumeClaimTemplate:
-              spec:
-                accessModes:
-                  - ReadWriteOnce
-                resources:
-                  requests:
-                    storage: 1Gi
+            persistentVolumeClaim:
+              claimName: {{ .Values.component }}-workspace
           - name: maven-settings
-            volumeClaimTemplate:
-              spec:
-                accessModes:
-                  - ReadWriteOnce
-                resources:
-                  requests:
-                    storage: 1Gi
+            configMap:
+              name: {{ .Values.component }}-maven-settings
 

--- a/spring-boot-pipeline/templates/maven-settings.yaml
+++ b/spring-boot-pipeline/templates/maven-settings.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.component }}-maven-settings
+data:
+  settings.xml: |
+    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+              xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+      <localRepository>/workspace/source/.m2</localRepository>
+    </settings>

--- a/spring-boot-pipeline/templates/pipeline-pvc.yaml
+++ b/spring-boot-pipeline/templates/pipeline-pvc.yaml
@@ -2,19 +2,7 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.component }}-maven-repo
-spec:
-  resources:
-    requests:
-      storage: 1Gi
-  volumeMode: Filesystem
-  accessModes:
-    - ReadWriteOnce
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: {{ .Values.component }}-maven-settings
+  name: {{ .Values.component }}-workspace
 spec:
   resources:
     requests:

--- a/spring-boot-pipeline/templates/pipeline-run-job.yaml
+++ b/spring-boot-pipeline/templates/pipeline-run-job.yaml
@@ -18,7 +18,7 @@ spec:
               - /bin/sh
               - -c
               - |
-                tkn pipeline start {{ .Values.component }}-service -w name=maven-repo,claimName={{ .Values.component }}-maven-repo -w name=maven-settings,claimName={{ .Values.component }}-maven-settings --use-param-defaults
+                tkn pipeline start {{ .Values.component }}-service -w name=maven-repo,claimName={{ .Values.component }}-workspace -w name=maven-settings,config={{ .Values.component }}-maven-settings --use-param-defaults
             env:
               - name: HOME
                 value: /tekton/home

--- a/spring-boot-pipeline/templates/trigger-template.yaml
+++ b/spring-boot-pipeline/templates/trigger-template.yaml
@@ -38,19 +38,8 @@ spec:
           name: {{ .Values.component }}-service
         workspaces:
           - name: maven-repo
-            volumeClaimTemplate:
-              spec:
-                accessModes:
-                  - ReadWriteOnce
-                resources:
-                  requests:
-                    storage: 1Gi
+            persistentVolumeClaim:
+              claimName: {{ .Values.component }}-workspace
           - name: maven-settings
-            volumeClaimTemplate:
-              spec:
-                accessModes:
-                  - ReadWriteOnce
-                resources:
-                  requests:
-                    storage: 1Gi
-
+            configMap:
+              name: {{ .Values.component }}-maven-settings


### PR DESCRIPTION
- provides maven settings workspace with a configmap instead of a pvc
- standardizes pvc name for pipeline workspaces
- sets custom location for maven `.m2` that is persisted between steps 